### PR TITLE
Moved from exceptions to logerr, introduced a programmable logging frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,12 @@ To start the version checker run
 ```bash
 $ rosrun backbone multiplexer --topic test --message-type backbone/TestMsg
 ```
-**N.B**: do not put any slash at the start of the topic name, it is automatically included by the script
-
 The ```--message-type``` flag is optional, if it is not set, the node will wait for the first message to be published on the topic to access informations about its type.
+
+To see all the available flags run 
+```bash
+$ rosrun backbone multiplexer --help
+```
 
 You can also configure this node in a roslaunch file. Rememeber to load the required parameter on the parameter server.
 # Docs

--- a/python/backbone/version_checker.py
+++ b/python/backbone/version_checker.py
@@ -3,26 +3,31 @@ import roslib.message
 
 
 class VersionChecker:
-    def __init__(self, topic, msg_type) -> None:
+    def __init__(self, topic, msg_type,max_msgs_without_err = 1) -> None:
         self.topic = topic
         self.msg_type = msg_type
         self.msg_class = roslib.message.get_message_class(self.msg_type)
         self.sub = rospy.Subscriber(
-            f"/{self.topic}", self.msg_class, callback=self.check_version, queue_size=1
+            f"{self.topic}", self.msg_class, callback=self.check_version, queue_size=1
         )
         self.version = rospy.get_param(f"{self.topic}_version")
+        self.count_flag: int = 0
+        self.max_msgs_without_err: int = max_msgs_without_err
+    
     def check_version(self, msg) -> None:
         if "version" not in msg.__slots__:
-            raise WrongVersionException(
+            raise NoVersionFieldException(
                 f"Field version not present in msg fields, please remember to include it"
             )
         elif msg.version != self.version:
-            raise WrongVersionException(
-                f"Got version {msg.version}, expected {self.version}"
-            )
+            if self.count_flag == 0:
+                rospy.logerr(f"Got version {msg.version} of {self.msg_type}, expected version {self.version}")
+            self.count_flag  = (self.count_flag + 1) % self.max_msgs_without_err
+            
+
         else:
             return None
 
 
-class WrongVersionException(Exception):
+class NoVersionFieldException(Exception):
     pass

--- a/scripts/version_checker
+++ b/scripts/version_checker
@@ -4,9 +4,13 @@ import argparse
 import rospy
 import rostopic
 
-
+def check_positive(value):
+    ival = int(value)
+    if ival <= 0:
+        raise argparse.ArgumentTypeError(f"Got {ival}, please provide a positive non zero value")
+    else:
+        return ival
 def main() -> int:
-    rospy.init_node(name="version_checker", anonymous=True)
     parser = argparse.ArgumentParser(
         description="Checks the version of the messages sent to a topic"
     )
@@ -26,7 +30,19 @@ def main() -> int:
         help="Type of messages that gets published on target topic",
         required=False,
     )
+    parser.add_argument(
+        "-r",
+        "--rate",
+        metavar="100",
+        type=check_positive,
+        default=1,
+        required=False,
+        help="Sets how many incosistent messages to wait  before logging the error (default: 1)"
+    )
     args = parser.parse_args()
+    
+    rospy.init_node(name="version_checker", anonymous=True)
+    
     ver = rospy.get_param(f"{args.topic}_version", None)
     if args.message_type:
         message_type = args.message_type
@@ -37,7 +53,7 @@ def main() -> int:
             f"please remember to setup the {args.topic}_version parameter on the master node "
         )
     else:
-        checker = VersionChecker(f"{args.topic}", args.message_type)
+        checker = VersionChecker(f"{args.topic}", args.message_type,args.rate)
         rospy.spin()
         return 0
 


### PR DESCRIPTION
I have decided to move from exception raising to logging the info on the wrong version. Now we only raise an exception if the version field is not present in the message. I also introduced a way to specify how many messages with the wrong version the version checker should periodically wait before logging the error.